### PR TITLE
006 - refactoring: 축제 도메인 API 기능 구현(축제 상세 페이지)

### DIFF
--- a/src/main/java/com/swyp10/domain/festival/controller/FestivalDetailController.java
+++ b/src/main/java/com/swyp10/domain/festival/controller/FestivalDetailController.java
@@ -1,6 +1,7 @@
 package com.swyp10.domain.festival.controller;
 
 import com.swyp10.domain.festival.dto.response.FestivalDetailResponse;
+import com.swyp10.domain.festival.service.FestivalDetailService;
 import com.swyp10.domain.festival.service.FestivalService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,11 +17,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "축제상세", description = "축제 상세 조회 API")
 public class FestivalDetailController {
 
-    private final FestivalService festivalService;
+    private final FestivalDetailService festivalDetailService;
 
     @Operation(summary = "축제 상세 조회", description = "축제 상세 조회")
     @GetMapping("/{festivalId}")
     public FestivalDetailResponse getFestivalDetail(@PathVariable Long festivalId) {
-        return festivalService.getFestivalDetail(festivalId);
+        return festivalDetailService.getFestivalDetail(festivalId);
     }
 }

--- a/src/main/java/com/swyp10/domain/festival/dto/response/FestivalDetailResponse.java
+++ b/src/main/java/com/swyp10/domain/festival/dto/response/FestivalDetailResponse.java
@@ -55,8 +55,6 @@ public class FestivalDetailResponse {
         private String contentid;
         @Schema(description = "원본 이미지 URL", required = false, nullable = true, example = "http://tong.visitkorea.or.kr/cms/resource/23/3493223_image2_1.JPG")
         private String originimgurl;
-        @Schema(description = "이미지명", required = false, nullable = true, example = "2025 태백 해바라기축제 5")
-        private String imgname;
         @Schema(description = "작은 이미지 URL", required = false, nullable = true, example = "http://tong.visitkorea.or.kr/cms/resource/23/3493223_image3_1.JPG")
         private String smallimageurl;
     }

--- a/src/main/java/com/swyp10/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/swyp10/domain/festival/repository/FestivalRepository.java
@@ -1,10 +1,12 @@
 package com.swyp10.domain.festival.repository;
 
 import com.swyp10.domain.festival.entity.Festival;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface FestivalRepository extends JpaRepository<Festival, Long>, FestivalCustomRepository {
+    @EntityGraph(attributePaths = {"basicInfo", "detailIntro", "detailImages"})
     Optional<Festival> findByContentId(String contentId);
 }

--- a/src/main/java/com/swyp10/domain/festival/service/FestivalDetailService.java
+++ b/src/main/java/com/swyp10/domain/festival/service/FestivalDetailService.java
@@ -1,0 +1,111 @@
+package com.swyp10.domain.festival.service;
+
+import com.swyp10.domain.festival.dto.response.FestivalDetailResponse;
+import com.swyp10.domain.festival.entity.Festival;
+import com.swyp10.domain.festival.entity.FestivalBasicInfo;
+import com.swyp10.domain.festival.entity.FestivalDetailIntro;
+import com.swyp10.domain.festival.entity.FestivalImage;
+import com.swyp10.domain.festival.repository.FestivalRepository;
+import com.swyp10.exception.ApplicationException;
+import com.swyp10.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FestivalDetailService {
+
+    private final FestivalRepository festivalRepository;
+
+    /**
+     * 축제 상세 조회
+     */
+    public FestivalDetailResponse getFestivalDetail(Long contentId) {
+        Festival festival = festivalRepository.findByContentId(String.valueOf(contentId))
+            .orElseThrow(() -> new ApplicationException(ErrorCode.FESTIVAL_NOT_FOUND, "축제를 찾을 수 없습니다. id=" + contentId));
+        return toDetailResponse(festival);
+    }
+
+    private FestivalDetailResponse toDetailResponse(Festival festival) {
+        FestivalBasicInfo basic = festival.getBasicInfo();
+        FestivalDetailIntro intro = festival.getDetailIntro();
+
+        // startDate/endDate는 상세의 "yyyy-MM-dd" String으로 노출
+        DateTimeFormatter yyyyMMdd = DateTimeFormatter.ofPattern("yyyyMMdd");
+        DateTimeFormatter yyyy_MM_dd = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        String startDateStr = (basic != null && basic.getEventstartdate() != null)
+            ? basic.getEventstartdate().format(yyyy_MM_dd) : null;
+        String endDateStr = (basic != null && basic.getEventenddate() != null)
+            ? basic.getEventenddate().format(yyyy_MM_dd) : null;
+
+        // theme는 Enum → displayName 또는 코드값 등 프로젝트 규칙에 맞춰서
+        String theme = festival.getTheme() != null ? festival.getTheme().getDisplayName() : null;
+
+        // 썸네일/좌표
+        String thumbnail = (basic != null) ? safeToString(basic.getFirstimage2()) : null;
+        String mapx = (basic != null && basic.getMapx() != null) ? String.valueOf(basic.getMapx()) : null;
+        String mapy = (basic != null && basic.getMapy() != null) ? String.valueOf(basic.getMapy()) : null;
+
+        // 이미지 목록
+        List<FestivalDetailResponse.ImageResponse> images = festival.getDetailImages() == null ? List.of()
+            : festival.getDetailImages().stream()
+            .map(this::toImageResponse)
+            .toList();
+
+        // content 블록
+        FestivalDetailResponse.ContentResponse content = FestivalDetailResponse.ContentResponse.builder()
+            .title(basic != null ? basic.getTitle() : null)
+            .homepage(basic != null ? intro.getEventhomepage() : null)
+            .addr1(basic != null ? basic.getAddr1() : null)
+            .addr2(basic != null ? basic.getAddr1() : null)
+            .overview(festival.getOverview())
+            .build();
+
+        // info 블록 (DetailIntro 중심, 값이 없으면 null 허용)
+        FestivalDetailResponse.InfoResponse info = FestivalDetailResponse.InfoResponse.builder()
+            .sponsor1(intro != null ? intro.getSponsor1() : null)
+            .sponsor1tel(intro != null ? intro.getSponsor1tel() : null)
+            .eventstartdate(basic != null && basic.getEventstartdate() != null ? basic.getEventstartdate().format(yyyyMMdd) : null)
+            .eventenddate(basic != null && basic.getEventenddate() != null ? basic.getEventenddate().format(yyyyMMdd) : null)
+            .playtime(intro != null ? intro.getPlaytime() : null)
+            .eventplace(intro != null ? intro.getEventplace() : null)
+            .eventhomepage(intro != null ? intro.getEventhomepage() : null)
+            .usetimefestival(intro != null ? intro.getUsetimefestival() : null)
+            .discountinfofestival(intro != null ? intro.getDiscountinfofestival() : null)
+            .spendtimefestival(intro != null ? intro.getSpendtimefestival() : null)
+            .build();
+
+        return FestivalDetailResponse.builder()
+            .id(Long.parseLong(festival.getContentId()))
+            .title(basic != null ? basic.getTitle() : null)
+            .address(basic != null ? basic.getAddr1() : null)
+            .theme(theme)
+            .startDate(startDateStr)
+            .endDate(endDateStr)
+            .thumbnail(thumbnail)
+            .mapx(mapx)
+            .mapy(mapy)
+            .images(images)
+            .content(content)
+            .info(info)
+            .build();
+    }
+
+    private FestivalDetailResponse.ImageResponse toImageResponse(FestivalImage img) {
+        return FestivalDetailResponse.ImageResponse.builder()
+            .contentid(img.getImgid())
+            .originimgurl(img.getOriginimgurl())
+            .smallimageurl(img.getSmallimageurl())
+            .build();
+    }
+
+    private String safeToString(Object o) {
+        return o == null ? null : String.valueOf(o);
+    }
+}

--- a/src/test/java/com/swyp10/domain/festival/repository/FestivalRepositoryTest.java
+++ b/src/test/java/com/swyp10/domain/festival/repository/FestivalRepositoryTest.java
@@ -1,0 +1,116 @@
+package com.swyp10.domain.festival.repository;
+
+import com.swyp10.config.TestConfig;
+import com.swyp10.domain.festival.entity.Festival;
+import com.swyp10.domain.festival.entity.FestivalBasicInfo;
+import com.swyp10.domain.festival.entity.FestivalDetailIntro;
+import com.swyp10.domain.festival.entity.FestivalImage;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@EntityScan(basePackages = "com.swyp10.domain")
+@Import({TestConfig.class, FestivalRepositoryTest.QuerydslTestConfig.class})
+@ActiveProfiles("test")
+class FestivalRepositoryTest {
+
+    @Autowired
+    FestivalRepository festivalRepository;
+
+    @TestConfiguration
+    static class QuerydslTestConfig {
+        @PersistenceContext
+        private EntityManager em;
+
+        @Bean
+        public com.querydsl.jpa.impl.JPAQueryFactory jpaQueryFactory() {
+            return new com.querydsl.jpa.impl.JPAQueryFactory(em);
+        }
+    }
+
+    @Test
+    @DisplayName("findByFestivalId - 연관 정보(EntityGraph)까지 한 번에 조회 성공")
+    void findByFestivalId_success() {
+        // given
+        Festival saved = festivalRepository.save(buildFestivalAggregate("테스트축제"));
+
+        // when
+        var found = festivalRepository.findByContentId(saved.getContentId());
+
+        // then
+        assertThat(found).isPresent();
+        Festival f = found.get();
+
+        // 기본 정보
+        assertThat(f.getBasicInfo()).isNotNull();
+        assertThat(f.getBasicInfo().getTitle()).isEqualTo("테스트축제");
+
+        // 상세 인트로
+        assertThat(f.getDetailIntro()).isNotNull();
+        assertThat(f.getDetailIntro().getEventplace()).isEqualTo("테스트장소");
+
+        // 이미지 컬렉션
+        assertThat(f.getDetailImages()).hasSize(2);
+        assertThat(f.getDetailImages().get(0).getOriginimgurl()).isEqualTo("http://img/1.jpg");
+    }
+
+    @Test
+    @DisplayName("findByFestivalId - 존재하지 않는 ID 조회 시 empty")
+    void findByFestivalId_notFound() {
+        // when
+        var found = festivalRepository.findByContentId(String.valueOf(999999L));
+
+        // then
+        assertThat(found).isEmpty();
+    }
+
+    private Festival buildFestivalAggregate(String title) {
+        FestivalBasicInfo basic = FestivalBasicInfo.builder()
+            .title(title)
+            .addr1("서울시 강남구 어딘가")
+            .eventstartdate(LocalDate.of(2025, 9, 1))
+            .eventenddate(LocalDate.of(2025, 9, 3))
+            .firstimage2("http://thumb/xxx.jpg")
+            .mapx(127.0123)
+            .mapy(37.1234)
+            .build();
+
+        FestivalDetailIntro intro = FestivalDetailIntro.builder()
+            .sponsor1("스폰서")
+            .sponsor1tel("010-0000-0000")
+            .eventplace("테스트장소")
+            .eventhomepage("<a href='http://example.com'>홈</a>")
+            .playtime("09:00~18:00")
+            .usetimefestival("무료")
+            .build();
+
+        List<FestivalImage> images = List.of(
+            FestivalImage.builder()
+                .imgid("1111").originimgurl("http://img/1.jpg").smallimageurl("http://img/1_s.jpg").build(),
+            FestivalImage.builder()
+                .imgid("2222").originimgurl("http://img/2.jpg").smallimageurl("http://img/2_s.jpg").build()
+        );
+
+        return Festival.builder()
+            .contentId("1234")
+            .overview("개요 텍스트")
+            .basicInfo(basic)
+            .detailIntro(intro)
+            .detailImages(images)
+            .build();
+    }
+}

--- a/src/test/java/com/swyp10/domain/festival/service/FestivalDetailServiceTest.java
+++ b/src/test/java/com/swyp10/domain/festival/service/FestivalDetailServiceTest.java
@@ -1,0 +1,114 @@
+package com.swyp10.domain.festival.service;
+
+import com.swyp10.config.TestConfig;
+import com.swyp10.domain.festival.dto.response.FestivalDetailResponse;
+import com.swyp10.domain.festival.entity.Festival;
+import com.swyp10.domain.festival.entity.FestivalBasicInfo;
+import com.swyp10.domain.festival.entity.FestivalDetailIntro;
+import com.swyp10.domain.festival.entity.FestivalImage;
+import com.swyp10.domain.festival.repository.FestivalRepository;
+import com.swyp10.exception.ApplicationException;
+import com.swyp10.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Import(TestConfig.class)
+@ActiveProfiles("test")
+@EntityScan(basePackages = "com.swyp10.domain")
+@Transactional
+@DisplayName("FestivalDetailService 테스트")
+class FestivalDetailServiceTest {
+
+    @Autowired
+    FestivalDetailService festivalDetailService;
+
+    @Autowired
+    FestivalRepository festivalRepository;
+
+    @Test
+    @DisplayName("축제 상세 조회 - DTO 매핑 성공")
+    void getFestivalDetail_success() {
+        // given
+        Festival saved = festivalRepository.save(buildFestivalAggregate("상세축제"));
+
+        // when
+        FestivalDetailResponse res = festivalDetailService.getFestivalDetail(Long.parseLong(saved.getContentId()));
+
+        // then
+        assertThat(res.getId()).isEqualTo(Long.parseLong(saved.getContentId()));
+        assertThat(res.getTitle()).isEqualTo("상세축제");
+        assertThat(res.getAddress()).isEqualTo("서울시 강남구 어딘가");
+        assertThat(res.getStartDate()).isEqualTo("2025-09-01");
+        assertThat(res.getEndDate()).isEqualTo("2025-09-03");
+        assertThat(res.getThumbnail()).isEqualTo("http://thumb/xxx.jpg");
+        assertThat(res.getMapx()).isEqualTo("127.0123");
+        assertThat(res.getMapy()).isEqualTo("37.1234");
+
+        assertThat(res.getContent()).isNotNull();
+        assertThat(res.getContent().getTitle()).isEqualTo("상세축제");
+        assertThat(res.getContent().getOverview()).isEqualTo("개요 텍스트");
+
+        assertThat(res.getInfo()).isNotNull();
+        assertThat(res.getInfo().getEventplace()).isEqualTo("테스트장소");
+        assertThat(res.getImages()).hasSize(2);
+        assertThat(res.getImages().get(0).getOriginimgurl()).isEqualTo("http://img/1.jpg");
+    }
+
+    @Test
+    @DisplayName("축제 상세 조회 - 존재하지 않는 ID면 ApplicationException(NOT_FOUND 계열) 발생")
+    void getFestivalDetail_notFound() {
+        assertThatThrownBy(() -> festivalDetailService.getFestivalDetail(999999L))
+            .isInstanceOf(ApplicationException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.FESTIVAL_NOT_FOUND);
+    }
+
+    private Festival buildFestivalAggregate(String title) {
+        FestivalBasicInfo basic = FestivalBasicInfo.builder()
+            .title(title)
+            .addr1("서울시 강남구 어딘가")
+            .eventstartdate(LocalDate.of(2025, 9, 1))
+            .eventenddate(LocalDate.of(2025, 9, 3))
+            .firstimage2("http://thumb/xxx.jpg")
+            .mapx(127.0123)
+            .mapy(37.1234)
+            .build();
+
+        FestivalDetailIntro intro = FestivalDetailIntro.builder()
+            .sponsor1("스폰서")
+            .sponsor1tel("010-0000-0000")
+            .eventplace("테스트장소")
+            .eventhomepage("<a href='http://example.com'>홈</a>")
+            .playtime("09:00~18:00")
+            .usetimefestival("무료")
+            .build();
+
+        List<FestivalImage> images = List.of(
+            FestivalImage.builder()
+                .imgid("1111").originimgurl("http://img/1.jpg").smallimageurl("http://img/1_s.jpg").build(),
+            FestivalImage.builder()
+                .imgid("2222").originimgurl("http://img/2.jpg").smallimageurl("http://img/2_s.jpg").build()
+        );
+
+        return Festival.builder()
+            .contentId("1234")
+            .overview("개요 텍스트")
+            .basicInfo(basic)
+            .detailIntro(intro)
+            .detailImages(images)
+            .build();
+    }
+}


### PR DESCRIPTION
### 주요 변경 사항

- [x] Festival 관련 API 기능 구현
  - 축제 상세 페이지

---

### 참고 사항  
- 
 
---

### 추가 작업
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new service for retrieving detailed festival information, providing enhanced details and improved data mapping.
* **Bug Fixes**
  * Updated festival detail retrieval to ensure correct and complete information is displayed to users.
* **Tests**
  * Added comprehensive tests for both the festival detail service and repository to ensure reliability and correct data fetching.
* **Refactor**
  * Removed an unused image name field from festival detail responses for cleaner output.
  * Improved data fetching performance for festival details by optimizing related entity loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->