### PR TITLE
008 - feat: TravelCourse 도메인 Batch & API 기능 구현

### DIFF
--- a/src/main/java/com/swyp10/batch/controller/BatchController.java
+++ b/src/main/java/com/swyp10/batch/controller/BatchController.java
@@ -25,6 +25,7 @@ public class BatchController {
     private final JobLauncher jobLauncher;
     private final Job festivalSyncJob;
     private final Job restaurantSyncJob;
+    private final Job travelCourseSyncJob;
 
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/run-festival-sync")
@@ -49,6 +50,17 @@ public class BatchController {
     }
 
     @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/run-travel-course-sync")
+    public ResponseEntity<Map<String, Object>> runTravelCourseSyncJob() {
+        log.info("TravelCourse sync job requested by admin");
+
+        JobParameters params = createJobParameters();
+        JobExecution jobExecution = executeJob(travelCourseSyncJob, params, "travel course sync");
+
+        return ResponseEntity.ok(createJobResponse(jobExecution));
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/run-all-sync")
     public ResponseEntity<Map<String, Object>> runAllSyncJobs() {
         log.info("All sync jobs requested by admin");
@@ -64,8 +76,13 @@ public class BatchController {
             JobParameters restaurantParams = createJobParameters("restaurant");
             JobExecution restaurantExecution = executeJob(restaurantSyncJob, restaurantParams, "restaurant sync");
 
+            // TravelCourse 배치 실행
+            JobParameters courseParams = createJobParameters("travel-course");
+            JobExecution courseExecution = executeJob(travelCourseSyncJob, courseParams, "travel course sync");
+
             response.put("festivalJob", createJobResponse(festivalExecution));
             response.put("restaurantJob", createJobResponse(restaurantExecution));
+            response.put("travelCourseJob", createJobResponse(courseExecution));
             response.put("message", "All sync jobs started successfully");
 
         } catch (Exception e) {

--- a/src/main/java/com/swyp10/domain/travelcourse/batch/TravelCourseApiCaller.java
+++ b/src/main/java/com/swyp10/domain/travelcourse/batch/TravelCourseApiCaller.java
@@ -1,0 +1,60 @@
+package com.swyp10.domain.travelcourse.batch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swyp10.domain.festival.client.TourApiClient;
+import com.swyp10.domain.travelcourse.dto.tourapi.DetailInfoCourseDto;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.client.UnknownContentTypeException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+@Slf4j
+public class TravelCourseApiCaller {
+
+    private final TourApiClient tourApiClient;
+    private final String serviceKey;
+    private final TravelCourseBatchUtils batchUtils;
+
+    public TravelCourseApiCaller(TourApiClient tourApiClient, String serviceKey) {
+        this.tourApiClient = tourApiClient;
+        this.serviceKey = serviceKey;
+        this.batchUtils = new TravelCourseBatchUtils(new ObjectMapper());
+    }
+
+    /**
+     * 안전한 API 호출 - 예외 처리 포함
+     */
+    public <T> T safeCall(Supplier<T> apiCall, T fallbackValue) {
+        try {
+            return apiCall.get();
+        } catch (UnknownContentTypeException e) {
+            log.warn("XML response received, using fallback");
+            return fallbackValue;
+        } catch (FeignException e) {
+            log.warn("API error: {}, using fallback", e.getMessage());
+            return fallbackValue;
+        } catch (Exception e) {
+            log.warn("Unexpected error: {}, using fallback", e.getMessage());
+            return fallbackValue;
+        }
+    }
+
+    /**
+     * 안전한 API 호출 - 기본 null 반환
+     */
+    public <T> T safeCall(Supplier<T> apiCall) {
+        return safeCall(apiCall, null);
+    }
+
+    public List<DetailInfoCourseDto> fetchDetailInfo(String contentId, String contentTypeId) {
+        Map<String, Object> response = safeCall(() ->
+            tourApiClient.detailInfo2(serviceKey, "ETC", "swyp10", "json", contentId, contentTypeId));
+
+        return response != null ? batchUtils.parseDetailInfoCourseList(response) : Collections.emptyList();
+    }
+}

--- a/src/main/java/com/swyp10/domain/travelcourse/batch/TravelCourseBatchProcessor.java
+++ b/src/main/java/com/swyp10/domain/travelcourse/batch/TravelCourseBatchProcessor.java
@@ -1,0 +1,145 @@
+package com.swyp10.domain.travelcourse.batch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swyp10.domain.festival.batch.BatchResult;
+import com.swyp10.domain.festival.client.TourApiClient;
+import com.swyp10.domain.travelcourse.dto.tourapi.SearchTravelCourseDto;
+import com.swyp10.domain.travelcourse.service.TravelCourseService;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+public class TravelCourseBatchProcessor {
+
+    private final TourApiClient tourApiClient;
+    private final TravelCourseService travelCourseService;
+    private final ObjectMapper objectMapper;
+    private final String serviceKey;
+
+    private final TravelCourseApiCaller apiCaller;
+    private final TravelCourseBatchUtils batchUtils;
+
+    public TravelCourseBatchProcessor(TourApiClient tourApiClient, TravelCourseService travelCourseService,
+                                      ObjectMapper objectMapper, String serviceKey) {
+        this.tourApiClient = tourApiClient;
+        this.travelCourseService = travelCourseService;
+        this.objectMapper = objectMapper;
+        this.serviceKey = serviceKey;
+        this.apiCaller = new TravelCourseApiCaller(tourApiClient, serviceKey);
+        this.batchUtils = new TravelCourseBatchUtils(objectMapper);
+    }
+
+    public BatchResult processTravelCourseBatch(String contentTypeId, int pageSize) {
+        return processTravelCourseBatch(contentTypeId, pageSize, Integer.MAX_VALUE);
+    }
+
+    public BatchResult processTravelCourseBatch(String contentTypeId, int pageSize, int maxItems) {
+        BatchResult result = new BatchResult();
+
+        try {
+            int page = 1;
+            int totalCount = 0;
+            int processedItems = 0;
+
+            log.info("TravelCourse batch started - maxItems: {}", maxItems == Integer.MAX_VALUE ? "unlimited" : maxItems);
+
+            do {
+                List<SearchTravelCourseDto> travelCourses = fetchTravelCoursePage(contentTypeId, pageSize, page);
+
+                if (travelCourses.isEmpty()) {
+                    break;
+                }
+
+                if (page == 1) {
+                    totalCount = getTotalCount(contentTypeId, pageSize);
+                    int actualTotal = Math.min(totalCount, maxItems);
+                    log.info("Found {} total travel courses, processing {} items", totalCount, actualTotal);
+                }
+
+                // 최대 개수 제한 체크
+                if (processedItems + travelCourses.size() > maxItems) {
+                    // 남은 개수만큼만 처리
+                    int remainingItems = maxItems - processedItems;
+                    travelCourses = travelCourses.subList(0, Math.max(0, remainingItems));
+                    log.info("Limiting to {} remaining items to reach max limit", remainingItems);
+                }
+
+                processTravelCoursePage(travelCourses, result);
+                processedItems += travelCourses.size();
+
+                // 최대 개수에 도달하면 중단
+                if (processedItems >= maxItems) {
+                    log.info("Reached maximum item limit: {}, stopping batch", maxItems);
+                    break;
+                }
+
+                page++;
+                Thread.sleep(100); // API 부하 방지
+
+            } while ((page - 1) * pageSize < totalCount);
+
+            log.info("TravelCourse batch completed - processed: {}/{} items", processedItems, maxItems == Integer.MAX_VALUE ? "unlimited" : maxItems);
+
+        } catch (Exception e) {
+            log.error("TravelCourse batch processing failed", e);
+            throw new RuntimeException("TravelCourse batch failed", e);
+        }
+
+        return result;
+    }
+
+    private List<SearchTravelCourseDto> fetchTravelCoursePage(String contentTypeId, int pageSize, int page) {
+        try {
+            Map<String, Object> response = apiCaller.safeCall(() ->
+                tourApiClient.areaBasedList2(serviceKey, "ETC", "swyp10", "json",
+                    contentTypeId, pageSize, page));
+
+            return batchUtils.parseTravelCourseList(response);
+
+        } catch (Exception e) {
+            log.warn("Failed to fetch travel course page {}: {}", page, e.getMessage());
+            return List.of();
+        }
+    }
+
+    private int getTotalCount(String contentTypeId, int pageSize) {
+        try {
+            Map<String, Object> response = tourApiClient.areaBasedList2(
+                serviceKey, "ETC", "swyp10", "json", contentTypeId, 1, 1);
+
+            return batchUtils.extractTotalCount(response);
+
+        } catch (Exception e) {
+            log.warn("Failed to get total count, using default", e);
+            return 1000; // 기본값
+        }
+    }
+
+    private void processTravelCoursePage(List<SearchTravelCourseDto> travelCourses, BatchResult result) {
+        for (SearchTravelCourseDto travelCourse : travelCourses) {
+            try {
+                processSingleTravelCourse(travelCourse);
+                result.incrementSuccess();
+
+                if (result.getTotalProcessed() % 10 == 0) {
+                    log.info("Progress: {}", result);
+                }
+
+            } catch (Exception e) {
+                log.warn("Failed to process travel course {}: {}", travelCourse.getContentid(), e.getMessage());
+                result.incrementError();
+            }
+        }
+    }
+
+    private void processSingleTravelCourse(SearchTravelCourseDto searchDto) {
+        String contentId = searchDto.getContentid();
+        String contentTypeId = searchDto.getContenttypeid();
+
+        var detailInfoDtos = apiCaller.fetchDetailInfo(contentId, contentTypeId);
+
+        travelCourseService.saveOrUpdateTravelCourse(searchDto, detailInfoDtos);
+    }
+}

--- a/src/main/java/com/swyp10/domain/travelcourse/batch/TravelCourseBatchUtils.java
+++ b/src/main/java/com/swyp10/domain/travelcourse/batch/TravelCourseBatchUtils.java
@@ -3,12 +3,15 @@ package com.swyp10.domain.travelcourse.batch;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.swyp10.domain.travelcourse.dto.tourapi.DetailInfoCourseDto;
 import com.swyp10.domain.travelcourse.dto.tourapi.SearchTravelCourseDto;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+@Slf4j
 public class TravelCourseBatchUtils {
 
     private final ObjectMapper objectMapper;
@@ -55,11 +58,11 @@ public class TravelCourseBatchUtils {
         List<DetailInfoCourseDto> detailInfoList = new ArrayList<>();
         for (Map<String, Object> item : list) {
             detailInfoList.add(DetailInfoCourseDto.builder()
-                .serialnum(getStr(item, "serialnum"))
-                .coursename(getStr(item, "coursename"))
-                .coursedesc(getStr(item, "coursedesc"))
-                .coursedist(getStr(item, "coursedist"))
-                .coursestime(getStr(item, "coursestime"))
+                .subnum(getStr(item, "subnum"))
+                .subcontentid(getStr(item, "subcontentid"))
+                .subname(getStr(item, "subname"))
+                .subdetailoverview(getStr(item, "subdetailoverview"))
+                .subdetailimg(getStr(item, "subdetailimg"))
                 .build());
         }
         return detailInfoList;
@@ -82,5 +85,43 @@ public class TravelCourseBatchUtils {
             }
         }
         return current;
+    }
+
+    public List<SearchTravelCourseDto> parseTravelCourseList(Map<String, Object> response) {
+        try {
+            Map<String, Object> body = getNestedMap(response, "response", "body");
+            Map<String, Object> items = (Map<String, Object>) body.get("items");
+
+            if (items == null || items.get("item") == null) {
+                return Collections.emptyList();
+            }
+
+            Object itemObj = items.get("item");
+            List<Map<String, Object>> courseList;
+
+            if (itemObj instanceof List<?>) {
+                courseList = (List<Map<String, Object>>) itemObj;
+            } else {
+                courseList = List.of((Map<String, Object>) itemObj);
+            }
+
+            return courseList.stream()
+                .map(this::parseSearchTravelCourseDto)
+                .collect(Collectors.toList());
+
+        } catch (Exception e) {
+            log.warn("Failed to parse travel course list", e);
+            return Collections.emptyList();
+        }
+    }
+
+    public int extractTotalCount(Map<String, Object> response) {
+        try {
+            Map<String, Object> body = getNestedMap(response, "response", "body");
+            return Integer.parseInt(String.valueOf(body.get("totalCount")));
+        } catch (Exception e) {
+            log.warn("Failed to extract total count", e);
+            return 0;
+        }
     }
 }

--- a/src/main/java/com/swyp10/domain/travelcourse/dto/tourapi/DetailInfoCourseDto.java
+++ b/src/main/java/com/swyp10/domain/travelcourse/dto/tourapi/DetailInfoCourseDto.java
@@ -8,9 +8,9 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class DetailInfoCourseDto {
-    private String serialnum;
-    private String coursename;
-    private String coursedesc;
-    private String coursedist;
-    private String coursestime;
+    private String subnum;
+    private String subcontentid;
+    private String subname;
+    private String subdetailoverview;
+    private String subdetailimg;
 }

--- a/src/main/java/com/swyp10/domain/travelcourse/entity/TravelCourse.java
+++ b/src/main/java/com/swyp10/domain/travelcourse/entity/TravelCourse.java
@@ -19,11 +19,6 @@ public class TravelCourse extends BaseTimeEntity {
     @Column(name = "course_id")
     private Long courseId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "difficulty_level")
-    @Builder.Default
-    private TravelDifficulty difficultyLevel = TravelDifficulty.NORMAL;
-
     @Column(name = "content_id", unique = true, nullable = false, length = 32)
     private String contentId;
 
@@ -33,6 +28,11 @@ public class TravelCourse extends BaseTimeEntity {
     @OneToMany(mappedBy = "travelCourse", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<TravelCourseDetailInfo> detailInfos = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty_level")
+    @Builder.Default
+    private TravelDifficulty difficultyLevel = TravelDifficulty.NORMAL;
 
     public void updateBasicInfo(TravelCourseBasicInfo basicInfo) {
         this.basicInfo = basicInfo;

--- a/src/main/java/com/swyp10/domain/travelcourse/entity/TravelCourseDetailInfo.java
+++ b/src/main/java/com/swyp10/domain/travelcourse/entity/TravelCourseDetailInfo.java
@@ -20,16 +20,17 @@ public class TravelCourseDetailInfo {
     @JoinColumn(name = "travel_course_id")
     private TravelCourse travelCourse;
 
-    @Column(length = 10)
+    @Column
     private String subnum;
 
-    @Column(length = 50)
+    @Column
     private String subcontentid;
 
-    @Column(length = 255)
+    @Column
     private String subname;
 
-    @Column(columnDefinition = "TEXT")
+    @Lob
+    @Column
     private String subdetailoverview;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/swyp10/domain/travelcourse/entity/TravelCourseDetailInfo.java
+++ b/src/main/java/com/swyp10/domain/travelcourse/entity/TravelCourseDetailInfo.java
@@ -21,19 +21,19 @@ public class TravelCourseDetailInfo {
     private TravelCourse travelCourse;
 
     @Column(length = 10)
-    private String serialnum;
+    private String subnum;
+
+    @Column(length = 50)
+    private String subcontentid;
 
     @Column(length = 255)
-    private String coursename;
+    private String subname;
 
     @Column(columnDefinition = "TEXT")
-    private String coursedesc;
+    private String subdetailoverview;
 
-    @Column(length = 50)
-    private String coursedist;
-
-    @Column(length = 50)
-    private String coursestime;
+    @Column(columnDefinition = "TEXT")
+    private String subdetailimg;
 
     public void setTravelCourse(TravelCourse travelCourse) {
         this.travelCourse = travelCourse;

--- a/src/main/java/com/swyp10/domain/travelcourse/mapper/TravelCourseMapper.java
+++ b/src/main/java/com/swyp10/domain/travelcourse/mapper/TravelCourseMapper.java
@@ -30,11 +30,11 @@ public class TravelCourseMapper {
 
     public static TravelCourseDetailInfo toDetailInfo(DetailInfoCourseDto detailDto) {
         return TravelCourseDetailInfo.builder()
-            .serialnum(detailDto.getSerialnum())
-            .coursename(detailDto.getCoursename())
-            .coursedesc(detailDto.getCoursedesc())
-            .coursedist(detailDto.getCoursedist())
-            .coursestime(detailDto.getCoursestime())
+            .subnum(detailDto.getSubnum())
+            .subcontentid(detailDto.getSubcontentid())
+            .subname(detailDto.getSubname())
+            .subdetailoverview(detailDto.getSubdetailoverview())
+            .subdetailimg(detailDto.getSubdetailimg())
             .build();
     }
 

--- a/src/main/java/com/swyp10/domain/travelcourse/repository/TravelCourseCustomRepository.java
+++ b/src/main/java/com/swyp10/domain/travelcourse/repository/TravelCourseCustomRepository.java
@@ -1,0 +1,9 @@
+package com.swyp10.domain.travelcourse.repository;
+
+import com.swyp10.domain.travelcourse.entity.TravelCourse;
+
+import java.util.Optional;
+
+public interface TravelCourseCustomRepository {
+    Optional<TravelCourse> findOneByAreaCodeWithDetails(String areaCode);
+}

--- a/src/main/java/com/swyp10/domain/travelcourse/repository/TravelCourseCustomRepositoryImpl.java
+++ b/src/main/java/com/swyp10/domain/travelcourse/repository/TravelCourseCustomRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.swyp10.domain.travelcourse.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.swyp10.domain.travelcourse.entity.QTravelCourse;
+import com.swyp10.domain.travelcourse.entity.QTravelCourseDetailInfo;
+import com.swyp10.domain.travelcourse.entity.TravelCourse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class TravelCourseCustomRepositoryImpl implements TravelCourseCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<TravelCourse> findOneByAreaCodeWithDetails(String areaCode) {
+        QTravelCourse c = QTravelCourse.travelCourse;
+        QTravelCourseDetailInfo d = QTravelCourseDetailInfo.travelCourseDetailInfo;
+
+        TravelCourse course = queryFactory
+            .selectFrom(c)
+            .leftJoin(c.detailInfos, d).fetchJoin()
+            .where(c.basicInfo.areacode.eq(areaCode))
+            .orderBy(c.createdAt.desc())     // 최신 코스 우선
+            .limit(1)
+            .fetchOne();
+
+        return Optional.ofNullable(course);
+    }
+}

--- a/src/main/java/com/swyp10/domain/travelcourse/repository/TravelCourseRepository.java
+++ b/src/main/java/com/swyp10/domain/travelcourse/repository/TravelCourseRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface TravelCourseRepository extends JpaRepository<TravelCourse, Long> {
+public interface TravelCourseRepository extends JpaRepository<TravelCourse, Long>, TravelCourseCustomRepository {
     Optional<TravelCourse> findByContentId(String contentId);
 }

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -125,7 +125,10 @@ tourapi:
       content-type-id: "39"  # 음식점
       page-size: 100
       max-total-items: 100  # 최대 100개로 제한
-      enabled: true
+    travel-course:
+      content-type-id: "25"  # 여행코스
+      page-size: 100
+      max-total-items: 100   # 100개로 제한
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,7 +56,10 @@ tourapi:
       content-type-id: "39"  # 음식점
       page-size: 100
       max-total-items: 100  # 최대 100개로 제한
-      enabled: true
+    travel-course:
+      content-type-id: "25"  # 여행코스
+      page-size: 100
+      max-total-items: 100   # 100개로 제한
 
 springdoc:
   api-docs:

--- a/src/test/java/com/swyp10/domain/travelcourse/repository/TravelCourseCustomRepositoryImplTest.java
+++ b/src/test/java/com/swyp10/domain/travelcourse/repository/TravelCourseCustomRepositoryImplTest.java
@@ -1,0 +1,113 @@
+package com.swyp10.domain.travelcourse.repository;
+
+import com.swyp10.config.QueryDslConfig;
+import com.swyp10.config.TestConfig;
+import com.swyp10.domain.travelcourse.entity.TravelCourse;
+import com.swyp10.domain.travelcourse.entity.TravelCourseBasicInfo;
+import com.swyp10.domain.travelcourse.entity.TravelCourseDetailInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({TestConfig.class, QueryDslConfig.class})
+@EntityScan("com.swyp10.domain") // 엔티티 스캔
+@ActiveProfiles("test")
+class TravelCourseCustomRepositoryImplTest {
+
+    @Autowired
+    TravelCourseRepository travelCourseRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Test
+    @DisplayName("areacode로 최신 TravelCourse 1건 + detailInfos fetch-join 조회 - 성공")
+    void findOneByAreaCodeWithDetails_success() {
+        // given
+        String areacode = "11";
+
+        // 코스 A (먼저 저장)
+        TravelCourse courseA = TravelCourse.builder()
+            .contentId("111111")
+            .basicInfo(TravelCourseBasicInfo.builder()
+                .areacode(areacode)
+                .title("코스 A")
+                .mapx("127.10")
+                .mapy("37.50")
+                .build())
+            .build();
+
+        courseA.addDetailInfo(TravelCourseDetailInfo.builder()
+            .subnum("1111113")
+            .subcontentid("111111")
+            .subname("A-볼거리1")
+            .subdetailoverview("A 개요1")
+            .subdetailimg("https://a1.jpg")
+            .build());
+
+        // 코스 B (나중에 저장 -> createdAt 더 최신)
+        TravelCourse courseB = TravelCourse.builder()
+            .contentId("222222")
+            .basicInfo(TravelCourseBasicInfo.builder()
+                .areacode(areacode)
+                .title("코스 B")
+                .mapx("127.20")
+                .mapy("37.60")
+                .build())
+            .build();
+
+        courseB.addDetailInfo(TravelCourseDetailInfo.builder()
+            .subnum("2222223")
+            .subcontentid("222222")
+            .subname("B-볼거리1")
+            .subdetailoverview("B 개요1")
+            .subdetailimg("https://b1.jpg")
+            .build());
+        courseB.addDetailInfo(TravelCourseDetailInfo.builder()
+            .subnum("2222224")
+            .subcontentid("222222")
+            .subname("B-볼거리2")
+            .subdetailoverview("B 개요2")
+            .subdetailimg("https://b2.jpg")
+            .build());
+
+        travelCourseRepository.save(courseA);
+        travelCourseRepository.save(courseB);
+        em.flush();
+        em.clear();
+
+        // when
+        var opt = travelCourseRepository.findOneByAreaCodeWithDetails(areacode);
+
+        // then
+        assertThat(opt).isPresent();
+        TravelCourse found = opt.get();
+        // createdAt desc 정렬이므로 B가 나와야 함
+        assertThat(found.getContentId()).isEqualTo("222222");
+        assertThat(found.getDetailInfos()).hasSize(2); // fetch-join 확인
+        assertThat(found.getBasicInfo().getTitle()).isEqualTo("코스 B");
+    }
+
+    @Test
+    @DisplayName("areacode에 해당하는 코스가 없을 때 Optional.empty 반환 - 성공")
+    void findOneByAreaCodeWithDetails_empty() {
+        // given
+        String area = "99"; // 저장하지 않은 지역
+
+        // when
+        var opt = travelCourseRepository.findOneByAreaCodeWithDetails(area);
+
+        // then
+        assertThat(opt).isEmpty();
+    }
+}

--- a/src/test/java/com/swyp10/domain/travelcourse/service/TravelCourseServiceTest.java
+++ b/src/test/java/com/swyp10/domain/travelcourse/service/TravelCourseServiceTest.java
@@ -1,12 +1,25 @@
 package com.swyp10.domain.travelcourse.service;
 
+import com.swyp10.config.QueryDslConfig;
 import com.swyp10.config.TestConfig;
+import com.swyp10.domain.festival.entity.Festival;
+import com.swyp10.domain.festival.entity.FestivalBasicInfo;
+import com.swyp10.domain.festival.repository.FestivalRepository;
+import com.swyp10.domain.travelcourse.dto.request.FestivalTravelCoursePageRequest;
+import com.swyp10.domain.travelcourse.dto.response.FestivalTravelCourseListResponse;
 import com.swyp10.domain.travelcourse.dto.tourapi.DetailInfoCourseDto;
 import com.swyp10.domain.travelcourse.dto.tourapi.SearchTravelCourseDto;
 import com.swyp10.domain.travelcourse.entity.TravelCourse;
+import com.swyp10.domain.travelcourse.entity.TravelCourseBasicInfo;
+import com.swyp10.domain.travelcourse.entity.TravelCourseDetailInfo;
+import com.swyp10.domain.travelcourse.repository.TravelCourseRepository;
+import com.swyp10.exception.ApplicationException;
+import com.swyp10.exception.ErrorCode;
+import jakarta.annotation.Resource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
@@ -18,38 +31,192 @@ import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Import(TestConfig.class)
+@Import({TestConfig.class, QueryDslConfig.class})
+@EntityScan("com.swyp10.domain")
 @Transactional
 @DisplayName("TravelCourseService 테스트")
 public class TravelCourseServiceTest {
 
-    @Autowired
+    @Resource
     private TravelCourseService travelCourseService;
 
+    @Resource
+    private FestivalRepository festivalRepository;
+
+    @Resource
+    private TravelCourseRepository travelCourseRepository;
+
     @Test
-    @DisplayName("여행코스 저장 및 조회 성공")
+    @DisplayName("여행코스 저장 및 조회 - 성공")
     void saveAndFindTravelCourse_success() {
         SearchTravelCourseDto searchDto = SearchTravelCourseDto.builder()
-            .contentid("TEST-001")
+            .contentid("11111")
             .title("테스트 여행코스")
             .addr1("테스트 주소")
             .build();
 
         DetailInfoCourseDto detailDto = DetailInfoCourseDto.builder()
-            .serialnum("1")
-            .coursename("A 구간")
-            .coursedesc("테스트 설명")
-            .coursedist("5km")
-            .coursestime("2시간")
+            .subname("A 구간")
+            .subdetailimg("테스트 설명")
             .build();
 
         TravelCourse saved = travelCourseService.saveOrUpdateTravelCourse(searchDto, List.of(detailDto));
-        assertThat(saved.getContentId()).isEqualTo("TEST-001");
+        assertThat(saved.getContentId()).isEqualTo("11111");
 
-        TravelCourse found = travelCourseService.findByContentId("TEST-001");
+        TravelCourse found = travelCourseService.findByContentId("11111");
         assertThat(found).isNotNull();
         assertThat(found.getBasicInfo().getTitle()).isEqualTo("테스트 여행코스");
         assertThat(found.getDetailInfos()).hasSize(1);
-        assertThat(found.getDetailInfos().get(0).getCoursename()).isEqualTo("A 구간");
+        assertThat(found.getDetailInfos().get(0).getSubname()).isEqualTo("A 구간");
+    }
+
+    @Test
+    @DisplayName("festivalId → areacode 매칭 코스 1건과 detailInfos를 근처 볼거리로 매핑 - 성공")
+    void getFestivalTravelCourses_success() {
+        // given: festival 저장 (areacode=11)
+        Festival festival = Festival.builder()
+            .contentId("12345")
+            .basicInfo(FestivalBasicInfo.builder()
+                .title("축제")
+                .areacode("11")
+                .addr1("서울")
+                .mapx(127.00)
+                .mapy(37.50)
+                .build())
+            .build();
+        festivalRepository.save(festival);
+
+        // 해당 지역 TravelCourse 저장
+        TravelCourse course = TravelCourse.builder()
+            .contentId("111111")
+            .basicInfo(TravelCourseBasicInfo.builder()
+                .areacode("11")
+                .title("서울 도심 코스")
+                .mapx("127.10")
+                .mapy("37.55")
+                .build())
+            .build();
+        course.addDetailInfo(TravelCourseDetailInfo.builder()
+            .subnum("1").subcontentid("S-1").subname("청계천 산책").subdetailoverview("좋음").subdetailimg("https://a.jpg").build());
+        course.addDetailInfo(TravelCourseDetailInfo.builder()
+            .subnum("2").subcontentid("S-2").subname("북촌 한옥마을").subdetailoverview("아름다움").subdetailimg("https://b.jpg").build());
+        travelCourseRepository.save(course);
+
+        FestivalTravelCoursePageRequest req = FestivalTravelCoursePageRequest.builder()
+            .festivalId(festival.getFestivalId())
+            .build();
+
+        // when
+        FestivalTravelCourseListResponse res = travelCourseService.getFestivalTravelCourses(req);
+
+        // then
+        assertThat(res.getCourses()).hasSize(1);
+        assertThat(res.getCourses().get(0).getTitle()).isEqualTo("서울 도심 코스");
+        assertThat(res.getNearbyAttractions()).hasSize(2);
+        assertThat(res.getNearbyAttractions().get(0).getName()).isEqualTo("청계천 산책");
+        assertThat(res.getNearbyAttractions().get(0).getMapx()).isEqualTo("127.10");
+        assertThat(res.getNearbyAttractions().get(0).getMapy()).isEqualTo("37.55");
+    }
+
+    @Test
+    @DisplayName("festivalId가 존재하지 않으면 ApplicationException(FESTIVAL_NOT_FOUND) - 실패")
+    void getFestivalTravelCourses_festivalNotFound() {
+        // given
+        FestivalTravelCoursePageRequest req = FestivalTravelCoursePageRequest.builder()
+            .festivalId(999999L)
+            .build();
+
+        // expect
+        assertThatThrownBy(() -> travelCourseService.getFestivalTravelCourses(req))
+            .isInstanceOf(ApplicationException.class)
+            .hasMessageContaining("Festival not found")
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.FESTIVAL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("festival에 areacode가 없으면 ApplicationException(TRAVEL_COURSE_NOT_FOUND) - 실패")
+    void getFestivalTravelCourses_noAreaCode() {
+        // given: areacode null 인 festival
+        Festival festival = Festival.builder()
+            .contentId("111111")
+            .basicInfo(FestivalBasicInfo.builder()
+                .title("지역코드 없음 축제")
+                .areacode(null)
+                .build())
+            .build();
+        festivalRepository.save(festival);
+
+        FestivalTravelCoursePageRequest req = FestivalTravelCoursePageRequest.builder()
+            .festivalId(festival.getFestivalId())
+            .build();
+
+        // expect
+        assertThatThrownBy(() -> travelCourseService.getFestivalTravelCourses(req))
+            .isInstanceOf(ApplicationException.class)
+            .hasMessageContaining("Festival has no areaCode")
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.TRAVEL_COURSE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("지역에 코스가 없으면 빈 리스트 반환")
+    void getFestivalTravelCourses_noCourseInArea_returnsEmpty() {
+        // given: festival with areacode=33, 하지만 해당 지역 코스는 저장하지 않음
+        Festival festival = Festival.builder()
+            .contentId("111111")
+            .basicInfo(FestivalBasicInfo.builder()
+                .title("축제")
+                .areacode("33")
+                .build())
+            .build();
+        festivalRepository.save(festival);
+
+        FestivalTravelCoursePageRequest req = FestivalTravelCoursePageRequest.builder()
+            .festivalId(festival.getFestivalId())
+            .build();
+
+        // when
+        FestivalTravelCourseListResponse res = travelCourseService.getFestivalTravelCourses(req);
+
+        // then
+        assertThat(res.getCourses()).isEmpty();
+        assertThat(res.getNearbyAttractions()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("코스는 있으나 detailInfos가 없으면 nearbyAttractions는 빈 리스트")
+    void getFestivalTravelCourses_courseWithoutDetails() {
+        // given
+        Festival festival = Festival.builder()
+            .contentId("111111")
+            .basicInfo(FestivalBasicInfo.builder()
+                .title("축제")
+                .areacode("44")
+                .build())
+            .build();
+        festivalRepository.save(festival);
+
+        TravelCourse course = TravelCourse.builder()
+            .contentId("222222")
+            .basicInfo(TravelCourseBasicInfo.builder()
+                .areacode("44")
+                .title("코스 - 디테일 없음")
+                .mapx("127.30")
+                .mapy("37.70")
+                .build())
+            .build();
+        travelCourseRepository.save(course);
+
+        FestivalTravelCoursePageRequest req = FestivalTravelCoursePageRequest.builder()
+            .festivalId(festival.getFestivalId())
+            .build();
+
+        // when
+        FestivalTravelCourseListResponse res = travelCourseService.getFestivalTravelCourses(req);
+
+        // then
+        assertThat(res.getCourses()).hasSize(1);
+        assertThat(res.getNearbyAttractions()).isEmpty();
     }
 }


### PR DESCRIPTION
### 주요 변경 사항

- [x] TravelCourse Batch AutoRunner 구현
- [x] TravelCourse 관련 API 기능 구현
  - 축제 상세 페이지 관련 여행 코스 조회

---

### 참고 사항  
- 
 
---

### 추가 작업
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new travel course batch synchronization job with a dedicated REST endpoint and scheduled weekly execution.
  * Added batch processing and API integration for travel course data with configurable limits.
  * Added retrieval of festival-related travel courses and nearby attractions based on festival area codes.

* **Improvements**
  * Enhanced travel course detail data structure and mapping for richer subcontent information.
  * Updated configuration files to support travel course batch settings.
  * Added custom repository support for efficient travel course queries by area code.

* **Bug Fixes**
  * Improved robustness and error logging in travel course batch utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->