### PR TITLE
011 - feat: 이달의 축제 API 기능 구현 

### DIFF
--- a/init-db/00-init-permissions.sql
+++ b/init-db/00-init-permissions.sql
@@ -8,7 +8,7 @@ SELECT USER(), @@hostname;
 SELECT User, Host FROM mysql.user WHERE User = 'root';
 
 -- root 사용자에게 모든 권한 부여
-GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
+GRANT ALL PRIVILEGES ON *.* TO 'root'@'172.%' WITH GRANT OPTION;
 
 -- swyp10 데이터베이스가 없으면 생성
 CREATE DATABASE IF NOT EXISTS swyp10 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/init-db/00-init-permissions.sql
+++ b/init-db/00-init-permissions.sql
@@ -14,7 +14,7 @@ GRANT ALL PRIVILEGES ON *.* TO 'root'@'172.%' WITH GRANT OPTION;
 CREATE DATABASE IF NOT EXISTS swyp10 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- root 사용자가 swyp10 데이터베이스에 접근할 수 있도록 명시적 권한 부여
-GRANT ALL PRIVILEGES ON swyp10.* TO 'root'@'%';
+GRANT ALL PRIVILEGES ON swyp10.* TO 'root'@'172.%';
 
 -- 권한 적용
 FLUSH PRIVILEGES;

--- a/src/main/java/com/swyp10/domain/festival/controller/FestivalController.java
+++ b/src/main/java/com/swyp10/domain/festival/controller/FestivalController.java
@@ -3,6 +3,8 @@ package com.swyp10.domain.festival.controller;
 import com.swyp10.config.security.OptionalUserId;
 import com.swyp10.domain.festival.dto.request.*;
 import com.swyp10.domain.festival.dto.response.FestivalListResponse;
+import com.swyp10.domain.festival.dto.response.FestivalMonthlyTopListResponse;
+import com.swyp10.domain.festival.dto.response.FestivalMonthlyTopResponse;
 import com.swyp10.domain.festival.service.FestivalService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -56,6 +58,14 @@ public class FestivalController {
             @ModelAttribute @ParameterObject FestivalSearchRequest request
     ) {
         return festivalService.searchFestivals(userId, request);
+    }
+
+    @Operation(summary = "이달의 축제", description = "현재 월 기준으로 viewCount가 가장 높은 5개 축제 조회 (로그인 불필요)")
+    @GetMapping("/monthly-top")
+    public FestivalMonthlyTopListResponse getMonthlyTopFestivals(
+        @Parameter(hidden = true) @OptionalUserId Long userId  // 로그인 선택적, Swagger에서 숨김
+    ) {
+        return festivalService.getMonthlyTopFestivals(userId);
     }
 
     @Operation(

--- a/src/main/java/com/swyp10/domain/festival/dto/response/FestivalMonthlyTopListResponse.java
+++ b/src/main/java/com/swyp10/domain/festival/dto/response/FestivalMonthlyTopListResponse.java
@@ -1,0 +1,13 @@
+package com.swyp10.domain.festival.dto.response;
+
+import com.swyp10.global.page.PageResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@Schema(description = "이달의 축제 목록 응답")
+public class FestivalMonthlyTopListResponse extends PageResponse<FestivalMonthlyTopResponse> {
+    // 추가적인 필드가 필요한 경우 여기에 추가
+}

--- a/src/main/java/com/swyp10/domain/festival/dto/response/FestivalMonthlyTopResponse.java
+++ b/src/main/java/com/swyp10/domain/festival/dto/response/FestivalMonthlyTopResponse.java
@@ -1,0 +1,67 @@
+package com.swyp10.domain.festival.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.swyp10.domain.festival.entity.Festival;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+@Builder
+public class FestivalMonthlyTopResponse {
+    @Schema(description = "축제 ID", required = true, nullable = false, example = "1234")
+    private Long id;
+
+    @Schema(description = "썸네일 이미지 URL", required = false, nullable = true, example = "https://...")
+    private String thumbnail;
+
+    @Schema(description = "테마", required = false, nullable = true, example = "음식/미식")
+    private String theme;
+
+    @Schema(description = "축제명", required = true, nullable = false, example = "부산 불꽃축제")
+    private String title;
+
+    @Schema(description = "축제 설명", required = true, nullable = false, example = "매년 가을에 열리는...")
+    private String overview;
+
+    @Schema(description = "북마크 여부", required = true, nullable = false, example = "true")
+    private Boolean bookmarked;
+
+    @Schema(description = "주소", required = false, nullable = true, example = "부산광역시 해운대구")
+    private String address;
+
+    @Schema(description = "축제 시작일", required = false, nullable = true, example = "2025-09-01", type = "string", format = "date")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @Schema(description = "축제 종료일", required = false, nullable = true, example = "2025-09-03", type = "string", format = "date")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    @Schema(description = "경도(X좌표)", required = false, nullable = true, example = "127.5881015063")
+    private String map_x;
+
+    @Schema(description = "위도(Y좌표)", required = false, nullable = true, example = "36.9913818048")
+    private String map_y;
+
+    public static FestivalMonthlyTopResponse from(Festival festival) {
+        return FestivalMonthlyTopResponse.builder()
+            .id(festival.getFestivalId())
+            .thumbnail(festival.getBasicInfo() != null ? festival.getBasicInfo().getFirstimage2() : null)
+            .theme(festival.getTheme() != null ? festival.getTheme().name() : null)
+            .title(festival.getBasicInfo() != null ? festival.getBasicInfo().getTitle() : null)
+            .overview(festival.getOverview()) // overview 포함
+            .bookmarked(false) // 기본값으로 false 설정
+            .address(festival.getBasicInfo() != null ? festival.getBasicInfo().getAddr1() : null)
+            .startDate(festival.getBasicInfo() != null ? festival.getBasicInfo().getEventstartdate() : null)
+            .endDate(festival.getBasicInfo() != null ? festival.getBasicInfo().getEventenddate() : null)
+            .map_x(festival.getBasicInfo() != null && festival.getBasicInfo().getMapx() != null ?
+                String.valueOf(festival.getBasicInfo().getMapx()) : null)
+            .map_y(festival.getBasicInfo() != null && festival.getBasicInfo().getMapy() != null ?
+                String.valueOf(festival.getBasicInfo().getMapy()) : null)
+            .build();
+    }
+}

--- a/src/main/java/com/swyp10/domain/festival/dto/response/FestivalResponse.java
+++ b/src/main/java/com/swyp10/domain/festival/dto/response/FestivalResponse.java
@@ -90,7 +90,6 @@ public class FestivalResponse {
                 .description(festival.getOverview())
                 .thumbnail(festival.getBasicInfo().getFirstimage())
                 .location(Map.of("mapX", festival.getBasicInfo().getMapx(), "mapY", festival.getBasicInfo().getMapy()))
-                .region(festival.getRegion() != null ? RegionResponse.from(festival.getRegion()) : null)
                 .createdAt(festival.getCreatedAt())
                 .updatedAt(festival.getUpdatedAt())
                 .build();

--- a/src/main/java/com/swyp10/domain/festival/entity/Festival.java
+++ b/src/main/java/com/swyp10/domain/festival/entity/Festival.java
@@ -3,7 +3,6 @@ package com.swyp10.domain.festival.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.swyp10.common.BaseTimeEntity;
 import com.swyp10.domain.festival.enums.*;
-import com.swyp10.domain.region.entity.Region;
 import com.swyp10.domain.review.entity.UserReview;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -62,10 +61,6 @@ public class Festival extends BaseTimeEntity {
     @OneToOne(mappedBy = "festival", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private FestivalStatistics statistics;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "region_code", updatable = false)
-    private Region region;
-
     @OneToMany(mappedBy = "festival", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     @JsonIgnore
@@ -91,8 +86,10 @@ public class Festival extends BaseTimeEntity {
 
     // 연관 관계 메서드
     public void initializeStatistics() {
-        FestivalStatistics stats = FestivalStatistics.createEmpty(this);
-        this.statistics = stats;
+        if (this.statistics == null) {
+            FestivalStatistics stats = FestivalStatistics.createEmpty(this);
+            this.statistics = stats;
+        }
     }
 
     public void addDetailImage(FestivalImage image) {

--- a/src/main/java/com/swyp10/domain/festival/entity/FestivalStatistics.java
+++ b/src/main/java/com/swyp10/domain/festival/entity/FestivalStatistics.java
@@ -21,9 +21,6 @@ public class FestivalStatistics {
     @JoinColumn(name = "festival_id")
     private Festival festival;
 
-    @Column(name = "region_code", nullable = false)
-    private int regionCode;
-
     @Column(name = "view_count", nullable = false)
     private int viewCount;
 
@@ -42,7 +39,6 @@ public class FestivalStatistics {
     public static FestivalStatistics createEmpty(Festival festival) {
         return FestivalStatistics.builder()
             .festival(festival)
-            .regionCode(festival.getRegion().getRegionCode())
             .viewCount(0)
             .bookmarkCount(0)
             .ratingAvg(BigDecimal.ZERO)
@@ -51,13 +47,17 @@ public class FestivalStatistics {
     }
 
     @Builder
-    public FestivalStatistics(Festival festival, int regionCode, int viewCount, int bookmarkCount, BigDecimal ratingAvg, int ratingCount) {
+    public FestivalStatistics(Festival festival, int viewCount, int bookmarkCount, BigDecimal ratingAvg, int ratingCount) {
         this.festival = festival;
-        this.regionCode = regionCode;
         this.viewCount = viewCount;
         this.bookmarkCount = bookmarkCount;
         this.ratingAvg = ratingAvg;
         this.ratingCount = ratingCount;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/swyp10/domain/festival/repository/FestivalCustomRepository.java
+++ b/src/main/java/com/swyp10/domain/festival/repository/FestivalCustomRepository.java
@@ -5,6 +5,7 @@ import com.swyp10.domain.festival.dto.request.FestivalMapRequest;
 import com.swyp10.domain.festival.dto.request.FestivalPersonalTestRequest;
 import com.swyp10.domain.festival.dto.request.FestivalSearchRequest;
 import com.swyp10.domain.festival.dto.response.FestivalDailyCountResponse;
+import com.swyp10.domain.festival.dto.response.FestivalMonthlyTopResponse;
 import com.swyp10.domain.festival.dto.response.FestivalSummaryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,4 +19,5 @@ public interface FestivalCustomRepository {
     List<FestivalDailyCountResponse.DailyCount> findDailyFestivalCounts(LocalDate startDate, LocalDate endDate);
     Page<FestivalSummaryResponse> findFestivalsForPersonalTest(FestivalPersonalTestRequest request, Pageable pageable);
     Page<FestivalSummaryResponse> searchFestivals(FestivalSearchRequest request, Pageable pageable);
+    List<FestivalMonthlyTopResponse> findTop5ByViewCountInCurrentMonth(LocalDate startOfMonth, LocalDate endOfMonth);
 }

--- a/src/main/java/com/swyp10/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/swyp10/domain/festival/repository/FestivalRepository.java
@@ -3,10 +3,17 @@ package com.swyp10.domain.festival.repository;
 import com.swyp10.domain.festival.entity.Festival;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface FestivalRepository extends JpaRepository<Festival, Long>, FestivalCustomRepository {
     @EntityGraph(attributePaths = {"basicInfo", "detailIntro", "detailImages"})
     Optional<Festival> findByContentId(String contentId);
+
+    @Modifying
+    @Query("UPDATE FestivalStatistics fs SET fs.viewCount = fs.viewCount + 1, fs.updatedAt = CURRENT_TIMESTAMP WHERE fs.festivalId = :festivalId")
+    int incrementViewCount(@Param("festivalId") Long festivalId);
 }

--- a/src/main/java/com/swyp10/domain/region/entity/Region.java
+++ b/src/main/java/com/swyp10/domain/region/entity/Region.java
@@ -26,10 +26,4 @@ public class Region extends BaseTimeEntity {
 
     @Column(name = "parent_code", length = 50)
     private String parentCode;
-
-    @OneToMany(mappedBy = "region", fetch = FetchType.LAZY)
-    @Builder.Default
-    @JsonIgnore
-    private List<Festival> festivals = new ArrayList<>();
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect   # MariaDBDialect

--- a/src/test/java/com/swyp10/domain/bookmark/repository/UserBookmarkRepositoryTest.java
+++ b/src/test/java/com/swyp10/domain/bookmark/repository/UserBookmarkRepositoryTest.java
@@ -69,7 +69,7 @@ class UserBookmarkRepositoryTest {
         );
 
         Optional<UserBookmark> found = userBookmarkRepository
-            .findByUser_UserIdAndFestival_ContentIdAndDeletedAtIsNull(user.getUserId(), String.valueOf(festival.getContentId()));
+            .findByUser_UserIdAndFestival_FestivalIdAndDeletedAtIsNull(user.getUserId(), festival.getFestivalId());
 
         assertThat(found).isPresent();
         assertThat(found.get().getBookmarkId()).isEqualTo(ub.getBookmarkId());
@@ -81,11 +81,11 @@ class UserBookmarkRepositoryTest {
     void existsActiveBookmark() {
         User user = saveUser();
         Festival festival = saveFestival();
-        String contentId = String.valueOf(festival.getContentId());
+        Long festivalId = festival.getFestivalId();
 
         // 없을 때 false
         boolean before = userBookmarkRepository
-            .existsByUser_UserIdAndFestival_ContentIdAndDeletedAtIsNull(user.getUserId(), contentId);
+            .existsByUser_UserIdAndFestival_FestivalIdAndDeletedAtIsNull(user.getUserId(), festivalId);
         assertThat(before).isFalse();
 
         // 생성하면 true
@@ -93,7 +93,7 @@ class UserBookmarkRepositoryTest {
             UserBookmark.builder().user(user).festival(festival).build()
         );
         boolean after = userBookmarkRepository
-            .existsByUser_UserIdAndFestival_ContentIdAndDeletedAtIsNull(user.getUserId(), contentId);
+            .existsByUser_UserIdAndFestival_FestivalIdAndDeletedAtIsNull(user.getUserId(), festivalId);
         assertThat(after).isTrue();
     }
 
@@ -112,7 +112,7 @@ class UserBookmarkRepositoryTest {
         userBookmarkRepository.save(ub);
 
         Optional<UserBookmark> found = userBookmarkRepository
-            .findByUser_UserIdAndFestival_ContentIdAndDeletedAtIsNull(user.getUserId(), String.valueOf(festival.getContentId()));
+            .findByUser_UserIdAndFestival_FestivalId(user.getUserId(), festival.getFestivalId());
 
         assertThat(found).isEmpty();
 

--- a/src/test/java/com/swyp10/domain/bookmark/service/UserBookmarkServiceTest.java
+++ b/src/test/java/com/swyp10/domain/bookmark/service/UserBookmarkServiceTest.java
@@ -47,7 +47,7 @@ class UserBookmarkServiceTest {
             // given
             when(festivalRepository.findByContentId(String.valueOf(festivalId))).thenReturn(Optional.of(festival()));
             when(userRepository.findById(userId)).thenReturn(Optional.of(user()));
-            when(bookmarkRepository.findByUser_UserIdAndFestival_ContentId(userId, String.valueOf(festivalId)))
+            when(bookmarkRepository.findByUser_UserIdAndFestival_FestivalId(userId, festivalId))
                 .thenReturn(Optional.empty());
             when(bookmarkRepository.save(any(UserBookmark.class)))
                 .thenAnswer(inv -> {
@@ -80,7 +80,7 @@ class UserBookmarkServiceTest {
                 .festival(festival())
                 .createdAt(LocalDateTime.now())
                 .build(); // deletedAt == null
-            when(bookmarkRepository.findByUser_UserIdAndFestival_ContentId(userId, String.valueOf(festivalId)))
+            when(bookmarkRepository.findByUser_UserIdAndFestival_FestivalId(userId, festivalId))
                 .thenReturn(Optional.of(existing));
 
             // expect
@@ -113,7 +113,7 @@ class UserBookmarkServiceTest {
             field.setAccessible(true);
             field.set(softDeleted, LocalDateTime.now().minusDays(1));
 
-            when(bookmarkRepository.findByUser_UserIdAndFestival_ContentId(userId, String.valueOf(festivalId)))
+            when(bookmarkRepository.findByUser_UserIdAndFestival_FestivalId(userId, festivalId))
                 .thenReturn(Optional.of(softDeleted));
 
             // when

--- a/src/test/java/com/swyp10/domain/festival/service/FestivalDetailServiceTest.java
+++ b/src/test/java/com/swyp10/domain/festival/service/FestivalDetailServiceTest.java
@@ -45,7 +45,7 @@ class FestivalDetailServiceTest {
         Festival saved = festivalRepository.save(buildFestivalAggregate("상세축제"));
 
         // when
-        FestivalDetailResponse res = festivalDetailService.getFestivalDetail(Long.parseLong(saved.getContentId()));
+        FestivalDetailResponse res = festivalDetailService.getFestivalDetail(saved.getFestivalId(), null);
 
         // then
         assertThat(res.getId()).isEqualTo(Long.parseLong(saved.getContentId()));
@@ -70,7 +70,7 @@ class FestivalDetailServiceTest {
     @Test
     @DisplayName("축제 상세 조회 - 존재하지 않는 ID면 ApplicationException(NOT_FOUND 계열) 발생")
     void getFestivalDetail_notFound() {
-        assertThatThrownBy(() -> festivalDetailService.getFestivalDetail(999999L))
+        assertThatThrownBy(() -> festivalDetailService.getFestivalDetail(999999L, null))
             .isInstanceOf(ApplicationException.class)
             .extracting("errorCode")
             .isEqualTo(ErrorCode.FESTIVAL_NOT_FOUND);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added public endpoint to fetch this month’s top 5 festivals, including bookmark status; no login required.
- Improvements
  - Festival view counts now increment on detail views; rankings reflect popularity.
- Breaking Changes
  - Removed region from festival responses.
  - Standardized bookmark lookups to use festivalId (was contentId), affecting related APIs.
- Chores
  - Restricted DB root access to 172.* hosts.
  - Switched schema generation to create-drop (environment-dependent).
- Tests
  - Added comprehensive tests for monthly top festivals and updated bookmark repository tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->